### PR TITLE
REF: refactor fill_gaps

### DIFF
--- a/geoplanar/gap.py
+++ b/geoplanar/gap.py
@@ -57,7 +57,6 @@ def gaps(gdf):
     return _gaps.iloc[gaps]
 
 
-
 def fill_gaps(gdf, gap_df=None, largest=True, inplace=False):
     """Fill any gaps in a geodataframe.
 
@@ -65,13 +64,14 @@ def fill_gaps(gdf, gap_df=None, largest=True, inplace=False):
     ----------
 
     gdf :  GeoDataFrame with polygon (multipolygon) GeoSeries
-    
+
 
     gap_df:  GeoDataFrame with gaps to fill
              If None, gaps will be determined
-    
+
     largest: boolean (Default: True)
-          Merge each gap with its largest (True), or smallest (False) neighbor
+          Merge each gap with its largest (True), or smallest (False) neighbor.
+          If None, merge with any neighbor non-deterministically but performantly.
 
     inplace: boolean (default: False)
           Change the geoseries of current dataframe
@@ -100,7 +100,8 @@ def fill_gaps(gdf, gap_df=None, largest=True, inplace=False):
     1     32.0
     dtype: float64
     """
-
+    from collections import defaultdict
+    from shapely.ops import unary_union
 
     if gap_df is None:
         gap_df = gaps(gdf)
@@ -108,19 +109,23 @@ def fill_gaps(gdf, gap_df=None, largest=True, inplace=False):
     if not inplace:
         gdf = gdf.copy()
 
-    for index, row in gap_df.iterrows():
-        rdf = geopandas.GeoDataFrame(geometry=[row.geometry])
-        neighbors = geopandas.sjoin(left_df=gdf, right_df=rdf, how='inner',
-                                    predicate='intersects')
-        if largest:
-            left = neighbors[neighbors.area==neighbors.area.max()]
+    gap_idx, gdf_idx = gdf.sindex.query_bulk(gap_df.geometry, predicate="intersects")
+
+    to_merge = defaultdict(set)
+    for g_ix in range(len(gap_df)):
+        neighbors = gdf_idx[gap_idx == g_ix]
+        if largest is None:  # don't care which polygon is a gap attached to
+            to_merge[neighbors[0]].add(g_ix)
+        elif largest:
+            to_merge[gdf.iloc[neighbors].area.idxmax()].add(g_ix)
         else:
-            left = neighbors[neighbors.area==neighbors.area.min()]
-        tmpdf = pandas.concat([left, rdf]).dissolve()
-        try:
-            geom = tmpdf.loc[0, 'geometry']
-            gdf.geometry[left.index] = geopandas.GeoDataFrame(geometry=[geom]).geometry.values
-        except:
-            print(index, tmpdf.shape)
+            to_merge[gdf.iloc[neighbors].area.idxmin()].add(g_ix)
+
+    new_geom = []
+    for k, v in to_merge.items():
+        new_geom.append(
+            unary_union([gdf.geometry.iloc[k]] + [gap_df.geometry.iloc[i] for i in v])
+        )
+    gdf.loc[gdf.index.take(list(to_merge.keys())), gdf.geometry.name] = new_geom
 
     return gdf

--- a/geoplanar/tests/test_gap.py
+++ b/geoplanar/tests/test_gap.py
@@ -9,32 +9,34 @@ from numpy.testing import assert_equal
 
 
 def setup():
-    p1 = box(0,0,10,10)
-    p2 = box(1,1, 3,3)
-    p3 = box(7,7, 9,9)
-    gdf = geopandas.GeoDataFrame(geometry=[p1,p2,p3])
+    p1 = box(0, 0, 10, 10)
+    p2 = box(1, 1, 3, 3)
+    p3 = box(7, 7, 9, 9)
+    gdf = geopandas.GeoDataFrame(geometry=[p1, p2, p3])
     return gdf
 
 
 def test_gaps():
-    p1 = box(0,0,10,10)
-    p2 = Polygon([(10,10), (12,8), (10,6), (12,4), (10,2), (20,5)])
-    gdf = geopandas.GeoDataFrame(geometry=[p1,p2])
+    p1 = box(0, 0, 10, 10)
+    p2 = Polygon([(10, 10), (12, 8), (10, 6), (12, 4), (10, 2), (20, 5)])
+    gdf = geopandas.GeoDataFrame(geometry=[p1, p2])
     h = gaps(gdf)
-    assert_equal(h.area.values, numpy.array([4.,4.]))
+    assert_equal(h.area.values, numpy.array([4.0, 4.0]))
 
 
 def test_fill_gaps():
-    p1 = box(0,0,10,10)
-    p2 = Polygon([(10,10), (12,8), (10,6), (12,4), (10,2), (20,5)])
-    gdf = geopandas.GeoDataFrame(geometry=[p1,p2])
+    p1 = box(0, 0, 10, 10)
+    p2 = Polygon([(10, 10), (12, 8), (10, 6), (12, 4), (10, 2), (20, 5)])
+    gdf = geopandas.GeoDataFrame(geometry=[p1, p2])
     gdf1 = fill_gaps(gdf)
-    assert_equal(gdf1.area.values, numpy.array([108.,32.]))
+    assert_equal(gdf1.area.values, numpy.array([108.0, 32.0]))
     gdf1 = fill_gaps(gdf, largest=False)
-    assert_equal(gdf1.area.values, numpy.array([100.,40.]))
-    p1 = box(0,0,10,10)
-    p2 = Polygon([(10,10), (12,8), (10,6), (12,4), (10,2), (20,5)])
-    gdf = geopandas.GeoDataFrame(geometry=[p1,p2])
+    assert_equal(gdf1.area.values, numpy.array([100.0, 40.0]))
+    gdf1 = fill_gaps(gdf, largest=None)
+    assert_equal(gdf1.area.values, numpy.array([108.0, 32.0]))
+    p1 = box(0, 0, 10, 10)
+    p2 = Polygon([(10, 10), (12, 8), (10, 6), (12, 4), (10, 2), (20, 5)])
+    gdf = geopandas.GeoDataFrame(geometry=[p1, p2])
     gaps_df = gaps(gdf).loc[[2]]
     filled = fill_gaps(gdf, gaps_df)
     assert_equal(filled.area, numpy.array([104, 32]))


### PR DESCRIPTION
Complete refactor of `fill_gaps` as the original version was super slow. 

On my data, I got from the original `Wall time: 33.5 s` to `Wall time: 1.91 s` if you want to select the largest polygon and to `Wall time: 209 ms` if you don't care which one gets the gaps (which is my case).