### PR TITLE
CI: update infrastructure

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -1,52 +1,57 @@
- on:
-   push:
-     branches:
-     - '*'
-   pull_request:
-     branches:
-     - '*'
-   schedule:
-     - cron: '59 21 * * *'
+name: Tests
 
- jobs:
-   unittests:
-     name: ${{ matrix.os }}, ${{ matrix.environment-file }}
-     runs-on: ${{ matrix.os }}
-     #timeout-minutes: 25
-     strategy:
-       matrix:
-         os: ['macos-latest', 'ubuntu-latest', 'windows-latest']
-         environment-file: [ci/37.yaml, ci/38.yaml, ci/39.yaml]
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches:
+      - "*"
+  schedule:
+    - cron: "0 0 * * 1,4"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Manual test execution
+        default: test
+        required: false
 
-     steps:
-       - name: checkout repo
-         uses: actions/checkout@v2
+jobs:
+  Test:
+    name: ${{ matrix.os }}, ${{ matrix.environment-file }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        environment-file:
+          - ci/envs/310-latest.yaml
+          - ci/envs/311-latest.yaml
+          - ci/envs/312-latest.yaml
+          - ci/envs/312-dev.yaml
+        include:
+          - environment-file: ci/envs/312-latest.yaml
+            os: macos-latest
+          - environment-file: ci/envs/312-latest.yaml
+            os: macos-14 # Apple Silicon
+          - environment-file: ci/envs/312-latest.yaml
+            os: windows-latest
+    defaults:
+      run:
+        shell: bash -l {0}
 
-       - name: setup micromamba
-         uses: mamba-org/provision-with-micromamba@main
-         with:
-           environment-file: ${{ matrix.environment-file }}
-           micromamba-version: 'latest'
+    steps:
+      - uses: actions/checkout@v4
 
-       - name: run tests - bash
-         shell: bash -l {0}
-         run: |
-           python -c 'import libpysal; libpysal.examples.fetch_all()'
-           pip install -e . --no-deps --force-reinstall
-           pytest -v geoplanar --cov=geoplanar --cov-report=xml
-         if: matrix.os != 'windows-latest'
+      - name: setup micromamba
+        uses: mamba-org/setup-micromamba@v1
+        with:
+          environment-file: ${{ matrix.environment-file }}
 
-       - name: run tests - powershell
-         shell: powershell
-         run:  |
-           python -c 'import libpysal; libpysal.examples.fetch_all()'
-           pip install -e . --no-deps --force-reinstall
-           pytest -v geoplanar --cov=geoplanar --cov-report=xml
-         if: matrix.os == 'windows-latest'
+      - name: Install geoplanar
+        run: pip install . --no-deps --force-reinstall
 
-       - name: ${{ matrix.os }}, ${{ matrix.environment-file }}
-         uses: codecov/codecov-action@v1
-         with:
-           token: ${{ secrets.CODECOV_TOKEN }}
-           file: ./coverage.xml
-           name: libpysal-codecov
+      - name: Test geoplanar
+        run: |
+          pytest -v --color yes --cov geoplanar --cov-append --cov-report term-missing --cov-report xml geoplanar
+
+      - uses: codecov/codecov-action@v4

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -24,6 +24,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         environment-file:
+          - ci/envs/310-oldest.yaml
           - ci/envs/310-latest.yaml
           - ci/envs/311-latest.yaml
           - ci/envs/312-latest.yaml

--- a/ci/310-latest.yaml
+++ b/ci/310-latest.yaml
@@ -2,9 +2,10 @@ name: test
 channels:
   - conda-forge
 dependencies:
-  - python=3.7
+  - python=3.10
   - libpysal
   - geopandas
+  - packaging
   - pytest
   - pytest-cov
   - codecov

--- a/ci/310-oldest.yaml
+++ b/ci/310-oldest.yaml
@@ -1,0 +1,11 @@
+name: test
+channels:
+  - conda-forge
+dependencies:
+  - python=3.10
+  - libpysal=4.6.0
+  - geopandas=0.10.2
+  - packaging
+  - pytest
+  - pytest-cov
+  - codecov

--- a/ci/311-latest.yaml
+++ b/ci/311-latest.yaml
@@ -2,9 +2,10 @@ name: test
 channels:
   - conda-forge
 dependencies:
-  - python=3.9
+  - python=3.11
   - libpysal
   - geopandas
+  - packaging
   - pytest
   - pytest-cov
   - codecov

--- a/ci/312-dev.yaml
+++ b/ci/312-dev.yaml
@@ -1,0 +1,18 @@
+name: test
+channels:
+  - conda-forge
+dependencies:
+  - python=3.12
+  - shapely
+  - pyogrio
+  - packaging
+  - pytest
+  - pytest-cov
+  - codecov
+  - pip
+  - pip:
+      # dev versions of packages
+      - --pre --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple --extra-index-url https://pypi.org/simple
+      - pandas
+      - git+https://github.com/geopandas/geopandas.git@main
+      - git+https://github.com/pysal/libpysal.git@main

--- a/ci/312-latest.yaml
+++ b/ci/312-latest.yaml
@@ -2,9 +2,10 @@ name: test
 channels:
   - conda-forge
 dependencies:
-  - python=3.8
+  - python=3.12
   - libpysal
   - geopandas
+  - packaging
   - pytest
   - pytest-cov
   - codecov

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,8 +1,12 @@
 version: 2
 build:
-  os: "ubuntu-20.04"
+  os: ubuntu-22.04
   tools:
-    python: "mambaforge-4.10"
-
+    python: mambaforge-latest
+python:
+  install:
+  - method: pip
+    path: .
 conda:
   environment: docs/environment.yml
+formats: []

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,6 @@ if os.path.exists("MANIFEST"):
     os.remove("MANIFEST")
 
 
-
 with open("requirements.txt") as f:
     tests_require = f.readlines()
 install_requires = [t.strip() for t in tests_require]
@@ -18,27 +17,24 @@ with open("README.md") as f:
     long_description = f.read()
 
 
-setup(name='geoplanar',
+setup(
+    name="geoplanar",
     version=versioneer.get_version(),
-    cmdclass=versioneer.get_cmdclass({"build_py": build_py}),  
-    description='Geographic planar enforcement of polygon geoseries',
+    cmdclass=versioneer.get_cmdclass({"build_py": build_py}),
+    description="Geographic planar enforcement of polygon geoseries",
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/sjsrey/geoplanar",
-    author='Serge Rey',
-    author_email='sjsrey@gmail.com',
+    author="Serge Rey",
+    author_email="sjsrey@gmail.com",
     license="3-Clause BSD",
-    packages=['geoplanar'],
+    packages=["geoplanar"],
     package_data={"": ["requirements.txt"]},
     classifiers=[
         "License :: OSI Approved :: BSD License",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: Implementation :: CPython",
     ],
-    python_requires=">=3.7",
+    python_requires=">=3.10",
     install_requires=install_requires,
     zip_safe=False,
 )


### PR DESCRIPTION
Updates the testing action and environment setup following the PySAL model. Adopts SPEC0 and drops support for old Python versions.

Again, the CI needs to be enabled in repo settings before this kicks in.