### PR TITLE
CI: pin old scipy in the oldest env

### DIFF
--- a/ci/310-oldest.yaml
+++ b/ci/310-oldest.yaml
@@ -6,6 +6,7 @@ dependencies:
   - libpysal=4.6.0
   - geopandas=0.10.2
   - scipy=1.8
+  - pandas=1.5
   - packaging
   - pytest
   - pytest-cov

--- a/ci/310-oldest.yaml
+++ b/ci/310-oldest.yaml
@@ -5,6 +5,7 @@ dependencies:
   - python=3.10
   - libpysal=4.6.0
   - geopandas=0.10.2
+  - scipy=1.8
   - packaging
   - pytest
   - pytest-cov

--- a/geoplanar/planar.py
+++ b/geoplanar/planar.py
@@ -38,9 +38,12 @@ def non_planar_edges(gdf):
     defaultdict(set, {0: {1}})
 
     """
-    w = libpysal.weights.Queen.from_dataframe(
-        gdf, use_index=False, silence_warnings=True
-    )
+    if Version(libpysal.__version__) >= Version("4.8.0"):
+        w = libpysal.weights.Queen.from_dataframe(
+            gdf, use_index=False, silence_warnings=True
+        )
+    else:
+        w = libpysal.weights.Queen.from_dataframe(gdf, silence_warnings=True)
 
     if Version(geopandas.__version__) >= Version("0.14.0"):
         intersections = gdf.sindex.query(gdf.geometry, predicate="intersects").T


### PR DESCRIPTION
This should make CI green, including the oldest supported env.