### PR TITLE
ENH: add largest=None to trim_overlaps

### DIFF
--- a/geoplanar/overlap.py
+++ b/geoplanar/overlap.py
@@ -21,9 +21,9 @@ def trim_overlaps(gdf, largest=True, inplace=False):
 
     Note
     ----
-    Under certain instances, polygons may turn into multipolygons.
-    This is expected due to the underlying topology of the polygons and may
-    require further treatment.
+    Under certain circumstances, the output may result in MultiPolygons. This is typically
+    a result of a complex relationship between geometries and is expected. Just note, 
+    that it may require further treatment if simple Polygons are needed.
 
     Parameters
     ----------

--- a/geoplanar/overlap.py
+++ b/geoplanar/overlap.py
@@ -19,15 +19,21 @@ def overlaps(gdf):
 def trim_overlaps(gdf, largest=True, inplace=False):
     """Trim overlapping polygons
 
+    Note
+    ----
+    Under certain instances, polygons may turn into multipolygons.
+    This is expected due to the underlying topology of the polygons and may
+    require further treatment.
 
     Parameters
     ----------
 
     gdf:  geodataframe with polygon geometries
 
-    largest: boolean
-             True: trim the larger of the pair of overlapping polygons,
-             False: trim the smaller polygon.
+    largest: boolean (Default: True)
+            True: trim the larger of the pair of overlapping polygons,
+            False: trim the smaller polygon.
+            If None, trim either polygon non-deterministically but performantly.
 
     Returns
     -------
@@ -42,7 +48,14 @@ def trim_overlaps(gdf, largest=True, inplace=False):
 
     if not inplace:
         gdf = gdf.copy()
-    if largest:
+    if largest == None: # don't care which polygon to trim
+        for i, j in intersections:
+            if i != j:
+                left = gdf.geometry[i]
+                right = gdf.geometry[j]
+                right = gdf.geometry[j].difference(gdf.geometry[i])
+                gdf.loc[j, gdf.geometry.name] = right
+    elif largest:
         for i, j in intersections:
             if i != j:
                 left = gdf.geometry[i]
@@ -64,7 +77,6 @@ def trim_overlaps(gdf, largest=True, inplace=False):
                 else:
                     left = gdf.geometry[i].difference(gdf.geometry[j])
                     gdf.loc[i, gdf.geometry.name] = left
-
     return gdf
 
 

--- a/geoplanar/tests/test_overlap.py
+++ b/geoplanar/tests/test_overlap.py
@@ -27,8 +27,15 @@ class TestOverlap:
         gdf1 = trim_overlaps(self.gdf, largest=False)
         assert_equal(gdf1.area.values, numpy.array([100.0, 4.0]))
 
+    def test_trim_overlaps_smallest(self):
+        gdf1 = trim_overlaps(self.gdf, largest=None)
+        assert_equal(gdf1.area.values, numpy.array([100.0, 4.0]))
+
     def test_trim_overlaps_multiple(self):
         gdf1 = trim_overlaps(self.gdf2, largest=False)
+        assert_equal(gdf1.area.values, numpy.array([100.0, 100.0, 0.0]))
+
+        gdf1 = trim_overlaps(self.gdf2, largest=None)
         assert_equal(gdf1.area.values, numpy.array([100.0, 100.0, 0.0]))
 
         gdf1 = trim_overlaps(self.gdf2)


### PR DESCRIPTION
Added the option to set largest=None to the trim_overlaps function, so that the process is faster if we don't care which polygons get trimmed. Also included some extra tests for this